### PR TITLE
Bump version to v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6758,7 +6758,7 @@ dependencies = [
 
 [[package]]
 name = "rebased-stardust-indexer"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebased-stardust-indexer"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -6,7 +6,7 @@
     "license": {
       "name": ""
     },
-    "version": "0.2.0"
+    "version": "0.4.0"
   },
   "servers": [
     {


### PR DESCRIPTION
# Description

Bumps the version to v0.4.0 for the new release.

# Notes

The version number in the Swagger file was aligned to v0.4.0 too.
