### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,32 +6,33 @@ on:
 
 jobs:
   build-and-publish:
-    name: Build and Push Docker Image to IOTA Registry
+    name: Build and Push Docker Image to iotaledger
     runs-on: ubuntu-latest
+    environment: release
 
     steps:
       # Checkout the repository
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      # Log in to the Docker Registry
-      - name: Log in to Docker Registry
-        uses: docker/login-action@v2
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_REGISTRY_USERNAME }}
           password: ${{ secrets.DOCKER_REGISTRY_PASSWORD }}
-          registry: ${{ secrets.DOCKER_REGISTRY_URL }}
 
       # Build the Docker image using Docker Compose with no cache
       - name: Build Docker Image
         run: docker compose build --no-cache
 
       # Tag the Docker image for the registry
-      - name: Tag Docker Image
+      - name: Tag built image
         run: |
-          docker tag rebased-stardust-indexer:latest docker-registry.iota.org/rebased-stardust-indexer:${{ github.ref_name }}
+          docker tag stardust-indexer iotaledger/stardust-indexer:latest
+          docker tag stardust-indexer iotaledger/stardust-indexer:${{ github.sha }}
 
       # Push the Docker image to the registry
-      - name: Push Docker Image
+      - name: Push image
         run: |
-          docker push docker-registry.iota.org/rebased-stardust-indexer:${{ github.ref_name }}
+          docker push iotaledger/stardust-indexer:latest
+          docker push iotaledger/stardust-indexer:${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Publish Docker Images
 
 on:
-  workflow_dispatch:
+  release:
+    types: [published]
 
 jobs:
   build-and-publish:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,7 @@
 name: Publish Docker Images
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
 
 jobs:
   build-and-publish:


### PR DESCRIPTION
Push image to Docker-hub repo:  

iotaledger/stardust-indexer:latest
iotaledger/stardust-indexer:version


Use vars under `release` environment.



