### PR TITLE
chore: update deps, rust toolchain & deny list based on latest iota deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,12 +29,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aead"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,21 +90,6 @@ name = "aliasable"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
-]
 
 [[package]]
 name = "allocator-api2"
@@ -484,22 +463,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-compression"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
-dependencies = [
- "brotli",
- "flate2",
- "futures-core",
- "memchr",
- "pin-project-lite",
- "tokio",
- "zstd",
- "zstd-safe",
-]
-
-[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -561,31 +524,6 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c2b7ddaa2c56a367ad27a094ad8ef4faacf8a617c2575acb2ba88949df999ca"
-dependencies = [
- "aws-lc-sys",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2ddd3ada61a305e1d8bb6c005d1eaa7d14d903681edfc400406d523a9b491"
-dependencies = [
- "bindgen 0.69.5",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
- "paste",
-]
 
 [[package]]
 name = "axum"
@@ -750,12 +688,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
@@ -843,8 +775,8 @@ dependencies = [
 
 [[package]]
 name = "bin-version"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "const-str",
  "git-version",
@@ -878,29 +810,6 @@ dependencies = [
  "rustc-hash 1.1.0",
  "shlex",
  "syn 2.0.98",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.8.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.98",
- "which",
 ]
 
 [[package]]
@@ -999,7 +908,7 @@ checksum = "23285ad32269793932e830392f2fe2f83e26488fd3ec778883a93c8323735780"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1010,7 +919,7 @@ checksum = "94230421e395b9920d23df13ea5d77a20e1725331f90fbbf6df6040b33f756ae"
 dependencies = [
  "arrayref",
  "arrayvec",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1023,7 +932,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.1",
+ "constant_time_eq",
 ]
 
 [[package]]
@@ -1090,30 +999,9 @@ dependencies = [
 
 [[package]]
 name = "bnum"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e31ea183f6ee62ac8b8a8cf7feddd766317adfb13ff469de57ce033efd6a790"
-
-[[package]]
-name = "brotli"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74fa05ad7d803d413eb8380983b092cbbaf9a85f151b871360e7b00cd7060b37"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
+checksum = "f781dba93de3a5ef6dc5b17c9958b208f6f3f021623b360fb605ea51ce443f10"
 
 [[package]]
 name = "bs58"
@@ -1238,30 +1126,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "chacha20"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "chacha20poly1305"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
-dependencies = [
- "aead",
- "chacha20",
- "cipher",
- "poly1305",
- "zeroize",
-]
-
-[[package]]
 name = "chrono"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,7 +1174,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
- "zeroize",
 ]
 
 [[package]]
@@ -1364,15 +1227,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cmake"
-version = "0.1.53"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e24a03c8b52922d68a1589ad61032f2c1aa5a8158d2aa0d93c6e9534944bbad6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "codespan"
@@ -1430,13 +1284,13 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
+ "iota-sdk-types",
  "rand 0.8.5",
  "serde",
- "shared-crypto",
 ]
 
 [[package]]
@@ -1448,8 +1302,20 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width 0.2.0",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "console"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03e45a4a8926227e4197636ba97a9fc9b00477e9f4bd711395687c5f0734bec4"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width 0.2.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1460,7 +1326,7 @@ checksum = "8030735ecb0d128428b64cd379809817e620a40e5001c54465b99ec5feec2857"
 dependencies = [
  "futures-core",
  "prost 0.13.4",
- "prost-types",
+ "prost-types 0.13.4",
  "tonic 0.12.3",
  "tracing-core",
 ]
@@ -1479,7 +1345,7 @@ dependencies = [
  "humantime",
  "hyper-util",
  "prost 0.13.4",
- "prost-types",
+ "prost-types 0.13.4",
  "serde",
  "serde_json",
  "thread_local",
@@ -1502,12 +1368,6 @@ name = "const-str"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
-
-[[package]]
-name = "constant_time_eq"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
@@ -1703,33 +1563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "curve25519-dalek"
-version = "4.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek-derive"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.98",
-]
-
-[[package]]
 name = "curve25519-dalek-ng"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,12 +1646,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dary_heap"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
-
-[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1854,7 +1681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1145d32e826a7748b69ee8fc62d3e6355ff7f1051df53141e7048162fc90481b"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2038,20 +1865,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -2062,17 +1880,6 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -2163,7 +1970,6 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
@@ -2175,7 +1981,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8 0.10.2",
- "serde",
  "signature 2.2.0",
  "zeroize",
 ]
@@ -2192,22 +1997,6 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-zebra"
-version = "4.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d9ce6874da5d4415896cd45ffbc4d1cfc0c4f9c079427bd870742c30f2f65a9"
-dependencies = [
- "curve25519-dalek",
- "ed25519",
- "hashbrown 0.14.5",
- "hex",
- "rand_core 0.6.4",
- "serde",
- "sha2 0.10.8",
  "zeroize",
 ]
 
@@ -2233,7 +2022,6 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -2256,7 +2044,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "serde_yaml",
 ]
@@ -2287,6 +2075,15 @@ checksum = "437cfb75878119ed8265685c41a115724eae43fb7cc5a0bf0e4ecc3b803af1c4"
 dependencies = [
  "autocfg",
  "scopeguard",
+]
+
+[[package]]
+name = "erased-discriminant"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a6df962265a53221f29081896c412ef325c17fa7d638cd9578febe53d3c82c"
+dependencies = [
+ "typeid",
 ]
 
 [[package]]
@@ -2501,12 +2298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fiat-crypto"
-version = "0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
 name = "filetime"
 version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2523,18 +2314,6 @@ name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcf0ed7fe52a17a03854ec54a9f76d6d84508d1c0e66bc1793301c73fc8493c"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
  "rand 0.8.5",
@@ -2593,12 +2372,6 @@ checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fsevent-sys"
@@ -2698,7 +2471,7 @@ version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
 dependencies = [
- "gloo-timers 0.2.6",
+ "gloo-timers",
  "send_wrapper",
 ]
 
@@ -2856,18 +2629,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "gloo-utils"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2962,11 +2723,6 @@ name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-dependencies = [
- "ahash",
- "allocator-api2",
- "serde",
-]
 
 [[package]]
 name = "hashbrown"
@@ -3057,15 +2813,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77e806677ce663d0a199541030c816847b36e8dc095f70dae4a4f4ad63da5383"
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "http"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3098,12 +2845,6 @@ dependencies = [
  "http-body",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "http-range-header"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9171a2ea8a68358193d15dd5d70c1c10a2afc3e7e4c5bc92bc9f025cebd7359c"
 
 [[package]]
 name = "httparse"
@@ -3400,16 +3141,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
- "parity-scale-codec 2.3.1",
-]
-
-[[package]]
-name = "impl-codec"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
-dependencies = [
- "parity-scale-codec 3.6.12",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -3417,15 +3149,6 @@ name = "impl-serde"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4551f042f3438e64dbd6226b20527fc84a6e1fe65688b58746a2f53623f25f5c"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "impl-serde"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc88fc67028ae3db0c853baa36269d398d5f45b6982f95549ff5def78c935cd"
 dependencies = [
  "serde",
 ]
@@ -3472,14 +3195,14 @@ dependencies = [
 
 [[package]]
 name = "indicatif"
-version = "0.17.11"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "183b3088984b400f4cfac3620d5e076c84da5364016b4f49473de574b2586235"
+checksum = "9375e112e4b463ec1b1c6c011953545c65a30164fbab5b581df32b3abf0dcb88"
 dependencies = [
- "console",
- "number_prefix",
+ "console 0.16.2",
  "portable-atomic",
  "unicode-width 0.2.0",
+ "unit-prefix",
  "web-time",
 ]
 
@@ -3525,7 +3248,7 @@ version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
 dependencies = [
- "console",
+ "console 0.15.10",
  "once_cell",
  "serde",
  "similar",
@@ -3549,7 +3272,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3575,9 +3298,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-common"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
+dependencies = [
+ "anyhow",
+ "fastcrypto",
+ "futures",
+ "iota-metrics",
+ "iota-types",
+ "parking_lot 0.12.3",
+ "prometheus",
+ "rand 0.8.5",
+ "reqwest",
+ "snap",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "iota-config"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3585,7 +3327,7 @@ dependencies = [
  "clap",
  "consensus-config",
  "csv",
- "dirs 5.0.1",
+ "dirs",
  "fastcrypto",
  "iota-genesis-common",
  "iota-keys",
@@ -3605,44 +3347,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-crypto"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a38db844c910d78825e173c083f2ef416b69cb091bba8ac1055763c6db065b"
-dependencies = [
- "aead",
- "aes",
- "aes-gcm",
- "autocfg",
- "base64 0.21.7",
- "blake2",
- "chacha20poly1305",
- "cipher",
- "curve25519-dalek",
- "digest 0.10.7",
- "ed25519-zebra",
- "generic-array",
- "getrandom 0.2.15",
- "hkdf",
- "hmac",
- "iterator-sorted 0.1.0",
- "k256",
- "num-traits",
- "pbkdf2 0.12.2",
- "rand 0.8.5",
- "scrypt",
- "serde",
- "sha2 0.10.8",
- "tiny-keccak",
- "unicode-normalization",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
 name = "iota-data-ingestion-core"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3675,8 +3382,8 @@ dependencies = [
 
 [[package]]
 name = "iota-enum-compat-util"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "serde_yaml",
 ]
@@ -3684,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3700,9 +3407,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-flamegraph-svg"
+version = "0.1.0"
+source = "git+https://github.com/iotaledger/flamegraph-svg?rev=ba681350dc9a72c9bae493b93840bdfbc01d0bbe#ba681350dc9a72c9bae493b93840bdfbc01d0bbe"
+
+[[package]]
 name = "iota-framework"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3714,8 +3426,8 @@ dependencies = [
 
 [[package]]
 name = "iota-framework-snapshot"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3730,8 +3442,8 @@ dependencies = [
 
 [[package]]
 name = "iota-genesis-common"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3741,8 +3453,8 @@ dependencies = [
 
 [[package]]
 name = "iota-http"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "bytes",
  "http",
@@ -3761,8 +3473,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3778,8 +3490,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-api"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3798,8 +3510,8 @@ dependencies = [
 
 [[package]]
 name = "iota-json-rpc-types"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3833,19 +3545,19 @@ dependencies = [
 
 [[package]]
 name = "iota-keys"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bip32",
  "fastcrypto",
+ "iota-sdk-types",
  "iota-types",
  "rand 0.8.5",
  "regex",
  "serde",
  "serde_json",
  "serde_with",
- "shared-crypto",
  "signature 1.6.4",
  "slip10_ed25519",
  "tiny-bip39",
@@ -3854,8 +3566,8 @@ dependencies = [
 
 [[package]]
 name = "iota-macros"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3865,8 +3577,8 @@ dependencies = [
 
 [[package]]
 name = "iota-metrics"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3891,8 +3603,8 @@ dependencies = [
 
 [[package]]
 name = "iota-move-build"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3914,7 +3626,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "bcs",
  "better_any",
@@ -3936,8 +3648,8 @@ dependencies = [
 
 [[package]]
 name = "iota-names"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3949,8 +3661,8 @@ dependencies = [
 
 [[package]]
 name = "iota-network-stack"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anemo",
  "bcs",
@@ -3979,8 +3691,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "schemars",
  "serde",
@@ -3990,8 +3702,8 @@ dependencies = [
 
 [[package]]
 name = "iota-open-rpc-macros"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -4003,14 +3715,14 @@ dependencies = [
 
 [[package]]
 name = "iota-package-management"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
  "iota-json-rpc-types",
  "iota-protocol-config",
- "iota-sdk 1.11.0",
+ "iota-sdk",
  "iota-types",
  "move-core-types",
  "move-package",
@@ -4020,8 +3732,8 @@ dependencies = [
 
 [[package]]
 name = "iota-package-resolver"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "async-trait",
  "bcs",
@@ -4036,8 +3748,8 @@ dependencies = [
 
 [[package]]
 name = "iota-proc-macros"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -4047,8 +3759,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -4062,8 +3774,8 @@ dependencies = [
 
 [[package]]
 name = "iota-protocol-config-macros"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4072,8 +3784,8 @@ dependencies = [
 
 [[package]]
 name = "iota-rest-api"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -4081,7 +3793,7 @@ dependencies = [
  "fastcrypto",
  "iota-network-stack",
  "iota-protocol-config",
- "iota-rust-sdk",
+ "iota-sdk-types",
  "iota-types",
  "itertools 0.13.0",
  "mime",
@@ -4100,61 +3812,9 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota-rust-sdk"
-version = "0.0.0"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d7084eaf0564f4e2381b2e8408ee1f7d51468450#d7084eaf0564f4e2381b2e8408ee1f7d51468450"
-dependencies = [
- "base64ct",
- "bcs",
- "blake2",
- "bnum",
- "bs58 0.5.1",
- "hex",
- "roaring",
- "schemars",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_with",
- "winnow 0.6.26",
-]
-
-[[package]]
 name = "iota-sdk"
-version = "1.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dfb0cae5c5bad8186576ca00b8be675257431eda028dcea01cb3b9f276037e"
-dependencies = [
- "bech32",
- "bitflags 2.8.0",
- "bytemuck",
- "derive_more 0.99.19",
- "getset",
- "gloo-timers 0.3.0",
- "hashbrown 0.14.5",
- "hex",
- "iota-crypto",
- "iota_stronghold",
- "iterator-sorted 0.2.0",
- "itertools 0.12.1",
- "lazy_static",
- "once_cell",
- "packable",
- "prefix-hex",
- "primitive-types 0.12.2",
- "rand 0.8.5",
- "regex",
- "serde",
- "serde_json",
- "serde_repr",
- "url",
- "zeroize",
-]
-
-[[package]]
-name = "iota-sdk"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4165,11 +3825,13 @@ dependencies = [
  "futures",
  "futures-core",
  "getset",
+ "iota-common",
  "iota-config",
  "iota-json",
  "iota-json-rpc-api",
  "iota-json-rpc-types",
  "iota-keys",
+ "iota-sdk-types",
  "iota-transaction-builder",
  "iota-types",
  "jsonrpsee",
@@ -4179,16 +3841,39 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_with",
- "shared-crypto",
  "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
 
 [[package]]
+name = "iota-sdk-types"
+version = "0.0.1-alpha.1"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=d8cdab6ab3f2fd9ba8059ba56e80ba950badc88d#d8cdab6ab3f2fd9ba8059ba56e80ba950badc88d"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "blake2",
+ "bnum",
+ "bs58 0.5.1",
+ "hex",
+ "itertools 0.13.0",
+ "paste",
+ "roaring",
+ "schemars",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "serde_with",
+ "strum 0.27.2",
+ "thiserror 2.0.11",
+ "winnow 0.7.1",
+]
+
+[[package]]
 name = "iota-simulator"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -4210,8 +3895,8 @@ dependencies = [
 
 [[package]]
 name = "iota-storage"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4259,8 +3944,8 @@ dependencies = [
 
 [[package]]
 name = "iota-transaction-builder"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4276,12 +3961,13 @@ dependencies = [
 
 [[package]]
 name = "iota-types"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anemo",
  "anyhow",
  "async-trait",
+ "base64 0.21.7",
  "bcs",
  "better_any",
  "bincode",
@@ -4301,8 +3987,7 @@ dependencies = [
  "iota-macros",
  "iota-network-stack",
  "iota-protocol-config",
- "iota-rust-sdk",
- "iota-sdk 1.1.5",
+ "iota-sdk-types",
  "itertools 0.13.0",
  "lru",
  "move-binary-format",
@@ -4315,10 +4000,10 @@ dependencies = [
  "num-rational",
  "num-traits",
  "once_cell",
- "packable",
  "parking_lot 0.12.3",
  "passkey-types",
  "prometheus",
+ "prost-types 0.14.3",
  "rand 0.8.5",
  "roaring",
  "schemars",
@@ -4326,7 +4011,6 @@ dependencies = [
  "serde-name",
  "serde_json",
  "serde_with",
- "shared-crypto",
  "signature 1.6.4",
  "starfish-config",
  "static_assertions",
@@ -4342,8 +4026,9 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
+ "bcs",
  "iota-types",
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4355,56 +4040,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "iota_stronghold"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c0d301c7edbc31494d183b7d24c1bb51d3fb10fce2f3793df1baf45b6988e10"
-dependencies = [
- "bincode",
- "hkdf",
- "iota-crypto",
- "rust-argon2",
- "serde",
- "stronghold-derive",
- "stronghold-utils",
- "stronghold_engine",
- "thiserror 1.0.69",
- "zeroize",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
-name = "iri-string"
-version = "0.7.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0f0a572e8ffe56e2ff4f769f32ffe919282c3916799f8b68688b6030063bea"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "iterator-sorted"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d101775d2bc8f99f4ac18bf29b9ed70c0dd138b9a1e88d7b80179470cbbe8bd2"
-
-[[package]]
-name = "iterator-sorted"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed3c1d66191fc266439b989dc1a9a69d9c4156e803ce456221231398b84c35d1"
 
 [[package]]
 name = "itertools"
@@ -4667,8 +4312,6 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "once_cell",
- "serdect",
  "sha2 0.10.8",
 ]
 
@@ -4729,30 +4372,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
-name = "libflate"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45d9dfdc14ea4ef0900c1cddbc8dcd553fbaacd8a4a282cf4018ae9dd04fb21e"
-dependencies = [
- "adler32",
- "core2",
- "crc32fast",
- "dary_heap",
- "libflate_lz77",
-]
-
-[[package]]
-name = "libflate_lz77"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e0d73b369f386f1c44abd9c570d5318f55ccde816ff4b562fa452e5182863d"
-dependencies = [
- "core2",
- "hashbrown 0.14.5",
- "rle-decode-fast",
-]
-
-[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4785,7 +4404,7 @@ version = "0.11.0+8.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
 dependencies = [
- "bindgen 0.65.1",
+ "bindgen",
  "bzip2-sys",
  "cc",
  "glob",
@@ -4793,23 +4412,6 @@ dependencies = [
  "libz-sys",
  "lz4-sys",
  "zstd-sys",
-]
-
-[[package]]
-name = "libsodium-sys-stable"
-version = "1.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7717550bb3ec725f7b312848902d1534f332379b1d575d2347ec265c8814566"
-dependencies = [
- "cc",
- "libc",
- "libflate",
- "minisign-verify",
- "pkg-config",
- "tar",
- "ureq",
- "vcpkg",
- "zip",
 ]
 
 [[package]]
@@ -4916,11 +4518,11 @@ dependencies = [
 
 [[package]]
 name = "matchers"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
- "regex-automata 0.1.10",
+ "regex-automata",
 ]
 
 [[package]]
@@ -4956,15 +4558,6 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
-
-[[package]]
-name = "memoffset"
-version = "0.6.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "migrations_internals"
@@ -5010,12 +4603,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "minisign-verify"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3"
-
-[[package]]
 name = "miniz_oxide"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5049,9 +4636,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.11"
+version = "0.12.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8261cd88c312e0004c1d51baad2980c66528dfdb2bee62003e643a4d8f86b077"
+checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -5059,7 +4646,6 @@ dependencies = [
  "equivalent",
  "parking_lot 0.12.3",
  "portable-atomic",
- "rustc_version",
  "smallvec",
  "tagptr",
  "uuid",
@@ -5068,7 +4654,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -5077,12 +4663,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -5097,12 +4683,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5118,7 +4704,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -5132,7 +4718,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -5147,7 +4733,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5157,7 +4743,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5177,7 +4763,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5212,7 +4798,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5223,7 +4809,7 @@ dependencies = [
  "move-proc-macros",
  "num",
  "once_cell",
- "primitive-types 0.10.1",
+ "primitive-types",
  "rand 0.8.5",
  "ref-cast",
  "serde",
@@ -5236,7 +4822,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5257,7 +4843,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5278,7 +4864,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "clap",
@@ -5301,7 +4887,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5319,7 +4905,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "hex",
@@ -5332,7 +4918,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5345,7 +4931,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5366,7 +4952,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "clap",
@@ -5402,7 +4988,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -5411,7 +4997,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5426,7 +5012,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "once_cell",
  "phf",
@@ -5436,7 +5022,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5447,7 +5033,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5456,7 +5042,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5466,7 +5052,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "better_any",
  "fail",
@@ -5486,7 +5072,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5500,7 +5086,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -5661,18 +5247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
-dependencies = [
- "bitflags 1.3.2",
- "cfg-if",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5730,12 +5304,11 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.46.0"
+version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "overload",
- "winapi",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5905,12 +5478,6 @@ dependencies = [
  "quote",
  "syn 2.0.98",
 ]
-
-[[package]]
-name = "number_prefix"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -6151,12 +5718,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "overload"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
-
-[[package]]
 name = "p256"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6166,31 +5727,6 @@ dependencies = [
  "elliptic-curve",
  "primeorder",
  "sha2 0.10.8",
-]
-
-[[package]]
-name = "packable"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11259b086696fc9256f790485d8f14f11f0fa60a60351af9693e3d49fd24fdb6"
-dependencies = [
- "autocfg",
- "packable-derive",
- "primitive-types 0.12.2",
- "serde",
-]
-
-[[package]]
-name = "packable-derive"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9567693dd2f9a4339cb0a54adfcc0cb431c0ac88b2e46c6ddfb5f5d11a1cc4f"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -6245,21 +5781,7 @@ dependencies = [
  "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive 2.3.1",
- "serde",
-]
-
-[[package]]
-name = "parity-scale-codec"
-version = "3.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "306800abfa29c7f16596b5970a588435e3d5b3149683d00c12b699cc19f895ee"
-dependencies = [
- "arrayvec",
- "bitvec 1.0.1",
- "byte-slice-cast",
- "impl-trait-for-tuples",
- "parity-scale-codec-derive 3.6.12",
+ "parity-scale-codec-derive",
  "serde",
 ]
 
@@ -6270,18 +5792,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
 dependencies = [
  "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "parity-scale-codec-derive"
-version = "3.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
-dependencies = [
- "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6562,17 +6072,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
-name = "poly1305"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
-dependencies = [
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6606,17 +6105,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prefix-hex"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1799f398371ad6957951ec446d3ff322d35c46d9db2e217b67e828b311c249"
-dependencies = [
- "hex",
- "primitive-types 0.12.2",
- "uint",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6641,21 +6129,9 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
- "fixed-hash 0.7.0",
- "impl-codec 0.5.1",
- "impl-serde 0.3.2",
- "uint",
-]
-
-[[package]]
-name = "primitive-types"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b34d9fd68ae0b74a41b21c03c2f62847aa0ffea044eee893b4c140b37e244e2"
-dependencies = [
- "fixed-hash 0.8.0",
- "impl-codec 0.6.0",
- "impl-serde 0.4.0",
+ "fixed-hash",
+ "impl-codec",
+ "impl-serde",
  "uint",
 ]
 
@@ -6763,8 +6239,8 @@ dependencies = [
 
 [[package]]
 name = "prometheus-closure-metric"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -6782,12 +6258,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.1",
+ "prost-derive 0.14.3",
 ]
 
 [[package]]
@@ -6805,12 +6281,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -6823,6 +6299,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc2f1e56baa61e93533aebc21af4d2134b70f66275e0fcdf3cbe43d77ff7e8fc"
 dependencies = [
  "prost 0.13.4",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
+dependencies = [
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -7154,7 +6639,7 @@ dependencies = [
 
 [[package]]
 name = "rebased-stardust-indexer"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "axum 0.7.9",
@@ -7240,17 +6725,8 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
- "regex-syntax 0.8.5",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -7261,14 +6737,8 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax",
 ]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -7363,16 +6833,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rle-decode-fast"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3582f63211428f83597b51b2ddb88e2a91a9d52d12831f9d08f5e624e8977422"
-
-[[package]]
 name = "roaring"
-version = "0.10.10"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a652edd001c53df0b3f96a36a8dc93fce6866988efc16808235653c6bcac8bf2"
+checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -7422,18 +6886,6 @@ dependencies = [
  "signature 2.2.0",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rust-argon2"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50162d19404029c1ceca6f6980fe40d45c8b369f6f44446fa14bb39573b5bb9"
-dependencies = [
- "base64 0.13.1",
- "blake2b_simd",
- "constant_time_eq 0.1.5",
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -7504,6 +6956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc_version_runtime"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dd18cd2bae1820af0b6ad5e54f4a51d0f3fcc53b05f845675074efcc7af071d"
+dependencies = [
+ "rustc_version",
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7535,7 +6997,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7544,7 +7006,6 @@ version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -7630,7 +7091,6 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -7658,15 +7118,6 @@ name = "ryu"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
-
-[[package]]
-name = "salsa20"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a22f5af31f73a954c10289c93e8a50cc23d971e80ee446f1f6f7137a088213"
-dependencies = [
- "cipher",
-]
 
 [[package]]
 name = "same-file"
@@ -7727,17 +7178,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "pbkdf2 0.12.2",
- "salsa20",
- "sha2 0.10.8",
-]
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7747,7 +7187,6 @@ dependencies = [
  "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -7853,13 +7292,16 @@ dependencies = [
 
 [[package]]
 name = "serde-reflection"
-version = "0.4.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6798a64289ff550d8d79847467789a5fd30b42c9c406a4d6dc0bc9b567e55c"
+checksum = "68fb2363ca88876b3e16442b02dde5305646fd50df297c79a4b54fc5f5cf51d4"
 dependencies = [
+ "erased-discriminant",
  "once_cell",
  "serde",
+ "serde_json",
  "thiserror 1.0.69",
+ "typeid",
 ]
 
 [[package]]
@@ -7904,15 +7346,16 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.138"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d434192e7da787e94a6ea7e9670b26a036d0ca41e0b7efb2676dd32bae872949"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
  "indexmap 2.12.0",
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
@@ -8000,16 +7443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serdect"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
-dependencies = [
- "base16ct",
- "serde",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8073,18 +7506,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "shared-crypto"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
-dependencies = [
- "bcs",
- "eyre",
- "fastcrypto",
- "serde",
- "serde_repr",
 ]
 
 [[package]]
@@ -8318,15 +7739,15 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "blake3",
  "fastcrypto",
  "iota-network-stack",
+ "iota-sdk-types",
  "rand 0.8.5",
  "rs_merkle",
  "serde",
- "shared-crypto",
 ]
 
 [[package]]
@@ -8334,64 +7755,6 @@ name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
-name = "stronghold-derive"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2835db23c4724c05a2f85b81c4681f4aa8ea158edc8a7f4ad791c916fb766c2e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "stronghold-runtime"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18db7cc51450cefdab5f4990e128dd02c98da6d2992b93ffef8992ac0d2f3ddf"
-dependencies = [
- "dirs 4.0.0",
- "iota-crypto",
- "libc",
- "libsodium-sys-stable",
- "log",
- "nix",
- "rand 0.8.5",
- "serde",
- "thiserror 1.0.69",
- "windows 0.36.1",
- "zeroize",
-]
-
-[[package]]
-name = "stronghold-utils"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8300214898af5e153e7f66e49dbd1c6a21585f2d592d9f24f58b969792475ed6"
-dependencies = [
- "rand 0.8.5",
- "stronghold-derive",
-]
-
-[[package]]
-name = "stronghold_engine"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd7371c42e557dd71a7f860bb2ec6b6fdb32f97a97987ccc2435fdd1f3a8615"
-dependencies = [
- "anyhow",
- "dirs-next",
- "hex",
- "iota-crypto",
- "once_cell",
- "paste",
- "serde",
- "stronghold-runtime",
- "thiserror 1.0.69",
- "zeroize",
-]
 
 [[package]]
 name = "strsim"
@@ -8424,6 +7787,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8446,6 +7818,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
  "syn 2.0.98",
 ]
 
@@ -8526,7 +7910,7 @@ dependencies = [
  "memchr",
  "ntapi",
  "rayon",
- "windows 0.57.0",
+ "windows",
 ]
 
 [[package]]
@@ -8587,20 +7971,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
-name = "tar"
-version = "0.4.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
-dependencies = [
- "filetime",
- "libc",
- "xattr",
-]
-
-[[package]]
 name = "telemetry-subscribers"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -8609,13 +7982,18 @@ dependencies = [
  "console-subscriber",
  "crossterm",
  "futures",
+ "iota-flamegraph-svg",
  "once_cell",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-proto",
  "opentelemetry_sdk",
+ "parking_lot 0.12.3",
  "prometheus",
  "prost 0.13.4",
+ "rand 0.8.5",
+ "rustc_version_runtime",
+ "serde",
  "thiserror 1.0.69",
  "tokio",
  "tonic 0.12.3",
@@ -8635,7 +8013,7 @@ dependencies = [
  "getrandom 0.3.1",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8764,15 +8142,6 @@ dependencies = [
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
-]
-
-[[package]]
-name = "tiny-keccak"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
-dependencies = [
- "crunchy",
 ]
 
 [[package]]
@@ -9033,7 +8402,7 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a82868bf299e0a1d2e8dce0dc33a46c02d6f045b2c1f1d6cc8dc3d0bf1812ef"
 dependencies = [
- "prost 0.14.1",
+ "prost 0.14.3",
  "tokio",
  "tokio-stream",
  "tonic 0.14.2",
@@ -9047,7 +8416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
- "prost 0.14.1",
+ "prost 0.14.3",
  "tonic 0.14.2",
 ]
 
@@ -9097,29 +8466,16 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
- "async-compression",
- "base64 0.21.7",
  "bitflags 2.8.0",
  "bytes",
- "futures-core",
- "futures-util",
  "http",
  "http-body",
  "http-body-util",
- "http-range-header",
- "httpdate",
- "iri-string",
- "mime",
- "mime_guess",
- "percent-encoding",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -9150,9 +8506,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -9174,9 +8530,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9185,9 +8541,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
@@ -9234,14 +8590,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.19"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex",
+ "regex-automata",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -9296,8 +8652,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "bcs",
  "bincode",
@@ -9323,8 +8679,8 @@ dependencies = [
 
 [[package]]
 name = "typed-store-derive"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
@@ -9334,12 +8690,18 @@ dependencies = [
 
 [[package]]
 name = "typed-store-error"
-version = "1.11.0"
-source = "git+https://github.com/iotaledger/iota.git?tag=v1.11.0#f4c3af7e48e5d12b4144fc5de49aec0c88c1da3f"
+version = "1.16.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.16.0-alpha#810392bc82460731a09db3ee7fceb1b91c795bb5"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
 ]
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
@@ -9427,6 +8789,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9447,18 +8815,6 @@ name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
-
-[[package]]
-name = "ureq"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
-dependencies = [
- "base64 0.22.1",
- "log",
- "once_cell",
- "url",
-]
 
 [[package]]
 name = "url"
@@ -9751,18 +9107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whoami"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9809,19 +9153,6 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53b97a83176b369b0eb2fd8158d4ae215357d02df9d40c1e1bf1879c5482c80"
-dependencies = [
- "windows_aarch64_msvc 0.36.1",
- "windows_i686_gnu 0.36.1",
- "windows_i686_msvc 0.36.1",
- "windows_x86_64_gnu 0.36.1",
- "windows_x86_64_msvc 0.36.1",
-]
 
 [[package]]
 name = "windows"
@@ -10034,12 +9365,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -10055,12 +9380,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10094,12 +9413,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -10115,12 +9428,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10160,12 +9467,6 @@ checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.36.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
@@ -10187,15 +9488,6 @@ name = "winnow"
 version = "0.5.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "winnow"
-version = "0.6.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]
@@ -10246,17 +9538,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "x25519-dalek"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
-dependencies = [
- "curve25519-dalek",
- "rand_core 0.6.4",
- "zeroize",
-]
-
-[[package]]
 name = "x509-parser"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10271,17 +9552,6 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.11",
  "time",
-]
-
-[[package]]
-name = "xattr"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
-dependencies = [
- "libc",
- "linux-raw-sys 0.4.15",
- "rustix 0.38.44",
 ]
 
 [[package]]
@@ -10380,7 +9650,6 @@ version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 dependencies = [
- "serde",
  "zeroize_derive",
 ]
 
@@ -10433,6 +9702,12 @@ dependencies = [
  "thiserror 2.0.11",
  "zopfli",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02aae0f83f69aafc94776e879363e9771d7ecbffe2c7fbb6c14c5e00dfe88439"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rebased-stardust-indexer"
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 
 [dependencies]
@@ -21,8 +21,8 @@ diesel_migrations = { version = "2.2.0", features = ["sqlite"] }
 
 dotenvy = "0.15"
 http = "1.2.0"
-iota-types = { git = "https://github.com/iotaledger/iota.git", tag = "v1.11.0", version = "1.11.0" }
-iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota.git", tag = "v1.11.0", version = "1.11.0" }
+iota-types = { git = "https://github.com/iotaledger/iota.git", tag = "v1.16.0-alpha", version = "1.16.0-alpha" }
+iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota.git", tag = "v1.16.0-alpha", version = "1.16.0-alpha" }
 num_enum = "0.7.3"
 prometheus = "0.14.0"
 serde = "1.0.215"
@@ -31,8 +31,8 @@ thiserror = "2.0.3"
 tokio = { version = "1.48", features = ["rt-multi-thread", "signal"] }
 tokio-util = "0.7.13"
 tower-http = { version = "0.6.2", features = ["cors"] }
-tracing = { version = "0.1.41", features = ["attributes"] }
-tracing-subscriber = "0.3.19"
+tracing = { version = "0.1.44", features = ["attributes"] }
+tracing-subscriber = "0.3.22"
 url = "2.5.4"
 utoipa = "5.2.0"
 utoipa-swagger-ui = { version = "8.0.3", features = ["axum"] }

--- a/deny.toml
+++ b/deny.toml
@@ -56,10 +56,10 @@ ignore = [
     "RUSTSEC-2024-0436",
     # backoff is unmaintained
     "RUSTSEC-2025-0012",
-    # Logging user input may result in poisoning logs with ANSI escape sequences
-    "RUSTSEC-2025-0055",
-    # number_prefix unmaintained
-    "RUSTSEC-2025-0119"
+    # bincode is unmaintained
+    "RUSTSEC-2025-0141",
+    # rustls-pemfile is unmaintained
+    "RUSTSEC-2025-0134",
 ]
 
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
@@ -90,8 +90,8 @@ allow = [
     "0BSD",
     "Unlicense",
     "BSL-1.0",
-    "OpenSSL",
     "Unicode-3.0",
+    "CDDL-1.0",
     "Zlib"
     # "Apache-2.0 WITH LLVM-exception",
 ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.90"
+channel = "1.92"


### PR DESCRIPTION
# Description of change

This PR updates the stardust indexer Cargo crates based on latest iota 1.16.0-alpha tag. This implies a bump for rust version and update to cargo deny.

## Links to any relevant issues

fixes #48 

## How the change has been tested

Started locally the stardust indexer with `alphanet` remote store, inspecting the logs checkpoints were syncing with no visible errors.