### PR TITLE
chore: update iota deps to include latest gRPC breaking changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "bin-version"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "const-str",
  "git-version",
@@ -1309,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -2064,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "serde_yaml",
 ]
@@ -3307,7 +3307,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3335,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "iota-common"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3357,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "iota-config"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3387,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "iota-data-ingestion-core"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3424,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "iota-enum-compat-util"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "serde_yaml",
 ]
@@ -3432,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3455,7 +3455,7 @@ source = "git+https://github.com/iotaledger/flamegraph-svg?rev=ba681350dc9a72c9b
 [[package]]
 name = "iota-framework"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3468,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "iota-framework-snapshot"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3484,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "iota-genesis-common"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3495,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "iota-grpc-client"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "async-stream",
  "base64 0.21.7",
@@ -3512,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "iota-grpc-types"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3528,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "iota-http"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "bytes",
  "http",
@@ -3549,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "iota-json"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3566,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-api"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3586,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-types"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3621,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "iota-keys"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3642,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "iota-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3653,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "iota-metrics"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3679,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "iota-move-build"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3701,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "bcs",
  "better_any",
@@ -3725,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "iota-names"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3738,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "iota-network-stack"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anemo",
  "bcs",
@@ -3768,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "schemars",
  "serde",
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3792,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "iota-package-management"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -3809,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "iota-package-resolver"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3825,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "iota-proc-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3836,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3851,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3861,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "iota-rest-api"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -3888,7 +3888,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3947,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "iota-simulator"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3970,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "iota-storage"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4019,7 +4019,7 @@ dependencies = [
 [[package]]
 name = "iota-tls"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -4041,7 +4041,7 @@ dependencies = [
 [[package]]
 name = "iota-transaction-builder"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4058,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4123,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "bcs",
  "iota-types",
@@ -4766,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4775,12 +4775,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4795,12 +4795,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4816,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -4830,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4845,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4855,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4875,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4910,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4934,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4955,7 +4955,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4976,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "clap",
@@ -4999,7 +4999,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -5017,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "hex",
@@ -5030,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -5043,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5064,7 +5064,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "clap",
@@ -5100,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -5109,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5124,7 +5124,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "once_cell",
  "phf",
@@ -5134,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5145,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5164,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "better_any",
  "fail",
@@ -5184,7 +5184,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5198,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6359,7 +6359,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -7826,7 +7826,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "blake3",
  "fastcrypto",
@@ -8039,7 +8039,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -8721,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "backoff",
  "bcs",
@@ -8749,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8759,7 +8759,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+source = "git+https://github.com/iotaledger/iota.git?tag=v1.20.0-alpha#643b6b8e2748c09c7dfde90181e967c2eeeddccd"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
  "rcgen",
  "ring",
  "rustls",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.8",
  "serde",
  "serde_json",
  "socket2 0.5.8",
@@ -225,6 +225,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 dependencies = [
  "derive_arbitrary",
+]
+
+[[package]]
+name = "arc-swap"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
+dependencies = [
+ "rustversion",
+ "serde",
 ]
 
 [[package]]
@@ -646,6 +656,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum-server"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1df331683d982a0b9492b38127151e6453639cd34926eb9c07d4cd8c6d22bfc"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "either",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "backoff"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,7 +808,7 @@ dependencies = [
 [[package]]
 name = "bin-version"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "const-str",
  "git-version",
@@ -1261,7 +1293,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1277,7 +1309,7 @@ dependencies = [
 [[package]]
 name = "consensus-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "fastcrypto",
  "iota-network-stack",
@@ -2032,7 +2064,7 @@ dependencies = [
 [[package]]
 name = "enum-compat-util"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "serde_yaml",
 ]
@@ -2359,6 +2391,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
+ "tokio",
 ]
 
 [[package]]
@@ -3265,7 +3307,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iota-adapter-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3293,7 +3335,7 @@ dependencies = [
 [[package]]
 name = "iota-common"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3315,7 +3357,7 @@ dependencies = [
 [[package]]
 name = "iota-config"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anemo",
  "anyhow",
@@ -3345,7 +3387,7 @@ dependencies = [
 [[package]]
 name = "iota-data-ingestion-core"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3360,7 +3402,6 @@ dependencies = [
  "iota-grpc-types",
  "iota-metrics",
  "iota-protocol-config",
- "iota-rest-api",
  "iota-sdk-types",
  "iota-storage",
  "iota-types",
@@ -3383,7 +3424,7 @@ dependencies = [
 [[package]]
 name = "iota-enum-compat-util"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "serde_yaml",
 ]
@@ -3391,7 +3432,7 @@ dependencies = [
 [[package]]
 name = "iota-execution"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "iota-adapter-latest",
  "iota-move-natives-latest",
@@ -3414,7 +3455,7 @@ source = "git+https://github.com/iotaledger/flamegraph-svg?rev=ba681350dc9a72c9b
 [[package]]
 name = "iota-framework"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "bcs",
  "iota-types",
@@ -3427,7 +3468,7 @@ dependencies = [
 [[package]]
 name = "iota-framework-snapshot"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3443,7 +3484,7 @@ dependencies = [
 [[package]]
 name = "iota-genesis-common"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "iota-execution",
  "iota-protocol-config",
@@ -3454,7 +3495,7 @@ dependencies = [
 [[package]]
 name = "iota-grpc-client"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "async-stream",
  "base64 0.21.7",
@@ -3462,6 +3503,7 @@ dependencies = [
  "http",
  "iota-grpc-types",
  "iota-sdk-types",
+ "prost 0.14.3",
  "serde",
  "thiserror 1.0.69",
  "tonic 0.14.2",
@@ -3470,7 +3512,7 @@ dependencies = [
 [[package]]
 name = "iota-grpc-types"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "bcs",
  "iota-sdk-types",
@@ -3486,7 +3528,7 @@ dependencies = [
 [[package]]
 name = "iota-http"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "bytes",
  "http",
@@ -3494,6 +3536,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
+ "iota-tls",
  "pin-project-lite",
  "socket2 0.5.8",
  "tokio",
@@ -3506,7 +3549,7 @@ dependencies = [
 [[package]]
 name = "iota-json"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3523,7 +3566,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-api"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3543,7 +3586,7 @@ dependencies = [
 [[package]]
 name = "iota-json-rpc-types"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3578,7 +3621,7 @@ dependencies = [
 [[package]]
 name = "iota-keys"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bip32",
@@ -3599,7 +3642,7 @@ dependencies = [
 [[package]]
 name = "iota-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "futures",
  "iota-proc-macros",
@@ -3610,7 +3653,7 @@ dependencies = [
 [[package]]
 name = "iota-metrics"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3636,7 +3679,7 @@ dependencies = [
 [[package]]
 name = "iota-move-build"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "fastcrypto",
@@ -3658,7 +3701,7 @@ dependencies = [
 [[package]]
 name = "iota-move-natives-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "bcs",
  "better_any",
@@ -3682,7 +3725,7 @@ dependencies = [
 [[package]]
 name = "iota-names"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -3695,7 +3738,7 @@ dependencies = [
 [[package]]
 name = "iota-network-stack"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anemo",
  "bcs",
@@ -3725,7 +3768,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "schemars",
  "serde",
@@ -3736,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "iota-open-rpc-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "derive-syn-parse",
  "itertools 0.13.0",
@@ -3749,7 +3792,7 @@ dependencies = [
 [[package]]
 name = "iota-package-management"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "iota-framework-snapshot",
@@ -3766,7 +3809,7 @@ dependencies = [
 [[package]]
 name = "iota-package-resolver"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "async-trait",
  "bcs",
@@ -3782,7 +3825,7 @@ dependencies = [
 [[package]]
 name = "iota-proc-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "msim-macros",
  "proc-macro2",
@@ -3793,7 +3836,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "clap",
  "iota-protocol-config-macros",
@@ -3808,7 +3851,7 @@ dependencies = [
 [[package]]
 name = "iota-protocol-config-macros"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3818,7 +3861,7 @@ dependencies = [
 [[package]]
 name = "iota-rest-api"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "axum 0.8.6",
@@ -3833,7 +3876,6 @@ dependencies = [
  "move-binary-format",
  "openapiv3",
  "prometheus",
- "reqwest",
  "schemars",
  "serde",
  "serde_json",
@@ -3841,13 +3883,12 @@ dependencies = [
  "serde_yaml",
  "tap",
  "tokio",
- "url",
 ]
 
 [[package]]
 name = "iota-sdk"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3882,7 +3923,7 @@ dependencies = [
 [[package]]
 name = "iota-sdk-types"
 version = "0.0.1-alpha.1"
-source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=654ddd7608ef5662611ae13edfe8cf4fd3b25ba0#654ddd7608ef5662611ae13edfe8cf4fd3b25ba0"
+source = "git+https://github.com/iotaledger/iota-rust-sdk.git?rev=e19c78a1bee17e0bf85fcd5b16a2f080cef26274#e19c78a1bee17e0bf85fcd5b16a2f080cef26274"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3906,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "iota-simulator"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anemo",
  "anemo-tower",
@@ -3929,7 +3970,7 @@ dependencies = [
 [[package]]
 name = "iota-storage"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3976,9 +4017,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "iota-tls"
+version = "1.20.0-alpha"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
+dependencies = [
+ "anyhow",
+ "arc-swap",
+ "axum 0.8.6",
+ "axum-server",
+ "ed25519",
+ "fastcrypto",
+ "pkcs8 0.10.2",
+ "rcgen",
+ "reqwest",
+ "rustls",
+ "rustls-webpki 0.103.8",
+ "tokio",
+ "tokio-rustls",
+ "tower-layer",
+ "x509-parser",
+]
+
+[[package]]
 name = "iota-transaction-builder"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3995,7 +4058,7 @@ dependencies = [
 [[package]]
 name = "iota-types"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anemo",
  "anyhow",
@@ -4060,7 +4123,7 @@ dependencies = [
 [[package]]
 name = "iota-verifier-latest"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "bcs",
  "iota-types",
@@ -4703,7 +4766,7 @@ dependencies = [
 [[package]]
 name = "move-abstract-interpreter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "move-binary-format",
  "move-bytecode-verifier-meter",
@@ -4712,12 +4775,12 @@ dependencies = [
 [[package]]
 name = "move-abstract-stack"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 
 [[package]]
 name = "move-binary-format"
 version = "0.0.3"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "enum-compat-util",
@@ -4732,12 +4795,12 @@ dependencies = [
 [[package]]
 name = "move-borrow-graph"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 
 [[package]]
 name = "move-bytecode-source-map"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4753,7 +4816,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "indexmap 2.12.0",
@@ -4767,7 +4830,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "move-abstract-interpreter",
  "move-abstract-stack",
@@ -4782,7 +4845,7 @@ dependencies = [
 [[package]]
 name = "move-bytecode-verifier-meter"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -4792,7 +4855,7 @@ dependencies = [
 [[package]]
 name = "move-command-line-common"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4812,7 +4875,7 @@ dependencies = [
 [[package]]
 name = "move-compiler"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4847,7 +4910,7 @@ dependencies = [
 [[package]]
 name = "move-core-types"
 version = "0.0.4"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4871,7 +4934,7 @@ dependencies = [
 [[package]]
 name = "move-coverage"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4892,7 +4955,7 @@ dependencies = [
 [[package]]
 name = "move-disassembler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -4913,7 +4976,7 @@ dependencies = [
 [[package]]
 name = "move-docgen"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "clap",
@@ -4936,7 +4999,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "codespan-reporting",
@@ -4954,7 +5017,7 @@ dependencies = [
 [[package]]
 name = "move-ir-to-bytecode-syntax"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "hex",
@@ -4967,7 +5030,7 @@ dependencies = [
 [[package]]
 name = "move-ir-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "hex",
  "move-command-line-common",
@@ -4980,7 +5043,7 @@ dependencies = [
 [[package]]
 name = "move-model-2"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "bcs",
@@ -5001,7 +5064,7 @@ dependencies = [
 [[package]]
 name = "move-package"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "clap",
@@ -5037,7 +5100,7 @@ dependencies = [
 [[package]]
 name = "move-proc-macros"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "quote",
  "syn 2.0.98",
@@ -5046,7 +5109,7 @@ dependencies = [
 [[package]]
 name = "move-stdlib-natives"
 version = "0.1.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "hex",
  "move-binary-format",
@@ -5061,7 +5124,7 @@ dependencies = [
 [[package]]
 name = "move-symbol-pool"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "once_cell",
  "phf",
@@ -5071,7 +5134,7 @@ dependencies = [
 [[package]]
 name = "move-trace-format"
 version = "0.0.1"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "move-binary-format",
  "move-core-types",
@@ -5082,7 +5145,7 @@ dependencies = [
 [[package]]
 name = "move-vm-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "move-binary-format",
  "once_cell",
@@ -5091,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "move-vm-profiler"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "move-vm-config",
  "once_cell",
@@ -5101,7 +5164,7 @@ dependencies = [
 [[package]]
 name = "move-vm-runtime"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "better_any",
  "fail",
@@ -5121,7 +5184,7 @@ dependencies = [
 [[package]]
 name = "move-vm-test-utils"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "move-binary-format",
@@ -5135,7 +5198,7 @@ dependencies = [
 [[package]]
 name = "move-vm-types"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "bcs",
  "move-binary-format",
@@ -6296,7 +6359,7 @@ dependencies = [
 [[package]]
 name = "prometheus-closure-metric"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "anyhow",
  "prometheus",
@@ -6342,7 +6405,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.98",
@@ -7060,15 +7123,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.22"
+version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
+checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
  "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.8",
  "subtle",
  "zeroize",
 ]
@@ -7109,11 +7172,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.11.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -7149,16 +7213,15 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
- "ring",
  "rustls-pki-types",
  "untrusted",
 ]
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7763,7 +7826,7 @@ dependencies = [
 [[package]]
 name = "starfish-config"
 version = "0.1.0"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "blake3",
  "fastcrypto",
@@ -7976,7 +8039,7 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 [[package]]
 name = "telemetry-subscribers"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "atomic_float",
  "bytes",
@@ -8658,7 +8721,7 @@ dependencies = [
 [[package]]
 name = "typed-store"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "backoff",
  "bcs",
@@ -8686,7 +8749,7 @@ dependencies = [
 [[package]]
 name = "typed-store-derive"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8696,7 +8759,7 @@ dependencies = [
 [[package]]
 name = "typed-store-error"
 version = "1.20.0-alpha"
-source = "git+https://github.com/iotaledger/iota.git?rev=78e9d17d48b14bef7bc1002979759f8f135b7c4b#78e9d17d48b14bef7bc1002979759f8f135b7c4b"
+source = "git+https://github.com/iotaledger/iota.git?rev=329933a9a290316a7fce1591faa61a247c35e93d#329933a9a290316a7fce1591faa61a247c35e93d"
 dependencies = [
  "serde",
  "thiserror 1.0.69",
@@ -9150,7 +9213,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ diesel_migrations = { version = "2.2.0", features = ["sqlite"] }
 
 dotenvy = "0.15"
 http = "1.2.0"
-iota-types = { git = "https://github.com/iotaledger/iota.git", rev = "329933a9a290316a7fce1591faa61a247c35e93d" }
-iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota.git", rev = "329933a9a290316a7fce1591faa61a247c35e93d" }
+iota-types = { git = "https://github.com/iotaledger/iota.git", tag = "v1.20.0-alpha", version = "1.20.0-alpha" }
+iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota.git", tag = "v1.20.0-alpha", version = "1.20.0-alpha" }
 num_enum = "0.7.3"
 prometheus = "0.14.0"
 serde = "1.0.215"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,8 +21,8 @@ diesel_migrations = { version = "2.2.0", features = ["sqlite"] }
 
 dotenvy = "0.15"
 http = "1.2.0"
-iota-types = { git = "https://github.com/iotaledger/iota.git", rev = "78e9d17d48b14bef7bc1002979759f8f135b7c4b" }
-iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota.git", rev = "78e9d17d48b14bef7bc1002979759f8f135b7c4b" }
+iota-types = { git = "https://github.com/iotaledger/iota.git", rev = "329933a9a290316a7fce1591faa61a247c35e93d" }
+iota-data-ingestion-core = { git = "https://github.com/iotaledger/iota.git", rev = "329933a9a290316a7fce1591faa61a247c35e93d" }
 num_enum = "0.7.3"
 prometheus = "0.14.0"
 serde = "1.0.215"


### PR DESCRIPTION
# Description of change

This [PR](https://github.com/iotaledger/iota/pull/10972) updates the iota dependencies to include the latest gRPC breaking changes, if not included the ingestion will fail with a proto error.

## Links to any relevant issues

fixes #56 

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

- [x] Basic tests (linting, compilation, formatting, unit/integration tests)
- [ ] Patch-specific tests (correctness, functionality coverage)

- Ran a local network with latest changes using `iota-localnet`
- Ran the rebased stardust indexer ingesting checkpoints form the local network